### PR TITLE
Parametrized test

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -388,21 +388,18 @@ def test_autocontrast_preserve_gradient():
     assert_image_equal(img, out)
 
 
-def test_autocontrast_preserve_onecolor():
-    def _test_one_color(color):
-        img = Image.new("RGB", (10, 10), color)
+@pytest.mark.parametrize(
+    "color", ((255, 255, 255), (127, 255, 0), (127, 127, 127), (0, 0, 0))
+)
+def test_autocontrast_preserve_one_color(color):
+    img = Image.new("RGB", (10, 10), color)
 
-        # single color images shouldn't change
-        out = ImageOps.autocontrast(img, cutoff=0, preserve_tone=True)
-        assert_image_equal(img, out)  # single color, no cutoff
+    # single color images shouldn't change
+    out = ImageOps.autocontrast(img, cutoff=0, preserve_tone=True)
+    assert_image_equal(img, out)  # single color, no cutoff
 
-        # even if there is a cutoff
-        out = ImageOps.autocontrast(
-            img, cutoff=0, preserve_tone=True
-        )  # single color 10 cutoff
-        assert_image_equal(img, out)
-
-    _test_one_color((255, 255, 255))
-    _test_one_color((127, 255, 0))
-    _test_one_color((127, 127, 127))
-    _test_one_color((0, 0, 0))
+    # even if there is a cutoff
+    out = ImageOps.autocontrast(
+        img, cutoff=0, preserve_tone=True
+    )  # single color 10 cutoff
+    assert_image_equal(img, out)


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/pull/5350

Makes use of https://docs.pytest.org/en/stable/parametrize.html, to effectively run the test four times with different inputs, instead of running one internal function four times.

Or see https://github.com/python-pillow/Pillow/blob/aa35f6b572c3491976e2336b28f481dad0a2a353/Tests/test_imagedraw.py#L709-L722 for a use of it in Pillow